### PR TITLE
Add Go linter for CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Go Linter
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7.0.0
+        with:
+          version: v2.0

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -20,7 +20,7 @@ func TestGenerateYesterdayReportWithOpenIssues(t *testing.T) {
 		{Title: "Another issue", URL: "https://api.github.com/example/repo/issues/2"},
 	}
 
-	generatedReport := GenerateYestedayReport(openedIssues, []github.PullRequest{}, []github.PullRequest{})
+	generatedReport := GenerateYesterdayReport(openedIssues, []github.PullRequest{}, []github.PullRequest{})
 
 	assert.Contains(t, generatedReport, "This is what you did yesterday:\n", "Generated report does not contain the expected header")
 	assert.Contains(t, generatedReport, "📋 Opened Open issue - https://api.github.com/example/repo/issues/1", "Generated report does not contain the expected opened issue")
@@ -33,7 +33,7 @@ func TestGenerateYesterdayReportWithOpenPullRequests(t *testing.T) {
 		{Title: "Another PR", URL: "https://api.github.com/example/repo/pull/2"},
 	}
 
-	generatedReport := GenerateYestedayReport([]github.Issue{}, openedPullRequests, []github.PullRequest{})
+	generatedReport := GenerateYesterdayReport([]github.Issue{}, openedPullRequests, []github.PullRequest{})
 
 	assert.Contains(t, generatedReport, "This is what you did yesterday:\n", "Generated report does not contain the expected header")
 	assert.Contains(t, generatedReport, "🔀 Opened Open PR - https://api.github.com/example/repo/pull/1", "Generated report does not contain the expected opened pull request")
@@ -45,7 +45,7 @@ func TestGenerateYesterdayReportWithReviewedPullRequests(t *testing.T) {
 		{Title: "Reviewed PR", URL: "https://api.github.com/example/repo/pull/3"},
 	}
 
-	generatedReport := GenerateYestedayReport([]github.Issue{}, []github.PullRequest{}, pullRequestsReviewed)
+	generatedReport := GenerateYesterdayReport([]github.Issue{}, []github.PullRequest{}, pullRequestsReviewed)
 
 	assert.Contains(t, generatedReport, "This is what you did yesterday:\n", "Generated report does not contain the expected header")
 	assert.Contains(t, generatedReport, "🔍 Reviewed Reviewed PR - https://api.github.com/example/repo/pull/3", "Generated report does not contain the expected reviewed pull request")


### PR DESCRIPTION
### Description
<!-- If this PR closes an issue, link it here. -->
Closes: https://github.com/mjimenez98/gh-stand-up/issues/9

<!-- Provide a summary of the changes you are making. Include the problem this solves or the feature it adds. -->

This pull request introduces a new GitHub Actions workflow for linting Go code and fixes a typo in the function name `GenerateYestedayReport` across multiple test cases.

### Type of change
<!-- Please mark the relevant option. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Other (please specify): Testing

### Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass with my changes.
- [x] I have checked my code for security vulnerabilities.
- [x] Any dependent changes have been merged.

### Testing
<!-- Describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. -->

- **Manual Tests Performed:** <!-- List any manual testing done --> N/A
- **Automated Tests:** <!-- List the automated tests added, if any --> A new CI check is added for linting

### Screenshots
<!-- Add screenshots or videos to help explain your PR, if applicable. -->

N/A

### Additional context
<!-- Add any other context or information about the pull request here. -->

N/A

### Security considerations
<!-- Highlight potential security concerns and how they were addressed. -->

- [x] I have reviewed the code for potential injection, XSS, and other vulnerabilities.
- [x] I have ensured sensitive data is not exposed.

### Reviewer notes
<!-- Any additional information for the reviewer to consider. -->

N/A
